### PR TITLE
BUGFIX: SD Card Mount Error on Thing Plus C

### DIFF
--- a/Firmware/Test Sketches/SD_Test/SD_Test.ino
+++ b/Firmware/Test Sketches/SD_Test/SD_Test.ino
@@ -10,7 +10,11 @@
 */
 #include "FS.h"
 #include "SD.h"
-#include "SPI.h"
+#include <SPI.h>
+
+#define SD_SCK 18
+#define SD_MISO 19
+#define SD_MOSI 23
 
 const int sd_cs = 5; //Thing Plus C
 
@@ -176,6 +180,9 @@ void setup() {
   Serial.begin(115200);
   delay(1000);
   Serial.println("SD test");
+
+  SPI.begin(SD_SCK, SD_MISO, SD_MOSI, sd_cs);
+  delay(100);
 
   if (!SD.begin(sd_cs)) {
     Serial.println("Card Mount Failed");


### PR DESCRIPTION
I had the following errors using VS Code 1.79.2 and PlatformIO 3.2.0 (2023-06-09) with the Thing Plus C:

```
[  1336][E][sd_diskio.cpp:199] sdCommand(): Card Failed! cmd: 0x00
[  1337][E][sd_diskio.cpp:802] sdcard_mount(): f_mount failed: (3) The physical drive cannot work
[  1643][E][sd_diskio.cpp:199] sdCommand(): Card Failed! cmd: 0x00
Card Mount Failed
```

Credit to [this post](https://github.com/espressif/arduino-esp32/issues/5967) for the bugfix.

Thanks!